### PR TITLE
feat: add sequential captcha navigation

### DIFF
--- a/captchaware/src/app/layout.tsx
+++ b/captchaware/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 import RandomCaptchaButton from "@/components/RandomCaptchaButton"
+import Navbar from "@/components/Navbar"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,12 +31,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 antialiased`}>
         <div className="flex min-h-screen flex-col">
-          <nav className="sticky top-0 z-10 w-full border-white/10 border-b bg-black/20 backdrop-blur-md">
-            <div className="container mx-auto flex items-center justify-between px-4 py-3">
-              <h1 className="font-bold text-white text-xl">CaptchaWare</h1>
-              <RandomCaptchaButton/>
-            </div>
-          </nav>
+          <Navbar />
           {children}
         </div>
       </body>

--- a/captchaware/src/components/CaptchaNaviguation.tsx
+++ b/captchaware/src/components/CaptchaNaviguation.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function CaptchaNavigation() {
+  const router = useRouter()
+  const [isSequence, setIsSequence] = useState(false)
+  const [nextCaptcha, setNextCaptcha] = useState<string | null>(null)
+
+  useEffect(() => {
+    const captchaSequence = localStorage.getItem('captchaSequence')
+    const currentIndex = localStorage.getItem('currentCaptchaIndex')
+    
+    if (captchaSequence && currentIndex) {
+      const sequence = JSON.parse(captchaSequence)
+      const index = Number.parseInt(currentIndex)
+      
+      setIsSequence(true)
+      
+      if (index < sequence.length - 1) {
+        setNextCaptcha(sequence[index + 1])
+      }
+    }
+  }, [])
+
+  const handleSkip = () => {
+    if (nextCaptcha) {
+      const currentIndex = Number.parseInt(localStorage.getItem('currentCaptchaIndex') || '0')
+      localStorage.setItem('currentCaptchaIndex', (currentIndex + 1).toString())
+      router.push(nextCaptcha)
+    } else {
+      localStorage.removeItem('captchaSequence')
+      localStorage.removeItem('currentCaptchaIndex')
+      router.push('/')
+    }
+  }
+
+  return isSequence ? (
+    <div className="fixed right-4 bottom-4">
+      <button 
+        type='button'
+        onClick={handleSkip}
+        className="rounded bg-red-500 px-4 py-2 font-bold text-white hover:bg-red-600"
+      >
+        Skip ce captcha
+      </button>
+    </div>
+  ) : null
+}

--- a/captchaware/src/components/ListCaptchaButton.tsx
+++ b/captchaware/src/components/ListCaptchaButton.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function ListCaptchaButton() {
+  const router = useRouter()
+  
+  const routeArray: string[] = [
+    "/oddCaptcha",
+    "/realCaptcha",
+    "/screamer",
+    "/binaryCaptcha",
+    "/whereIsWaldo",
+    "/wordleCaptcha",
+    "/roulette",
+    "/calculCaptcha",
+    "/guessCaptcha",
+    "/wordTTS",
+    "/chess",
+    "/people",
+    "/pineapplePizza",
+  ]
+
+  const startSequence = () => {
+    localStorage.setItem('captchaSequence', JSON.stringify(routeArray))
+    localStorage.setItem('currentCaptchaIndex', '0')
+    router.push(routeArray[0])
+  }
+
+  return (
+    <button 
+      type='button'
+      onClick={startSequence}
+      className="rounded bg-gradient-to-r from-blue-500 to-purple-500 px-4 py-2 font-bold text-white transition-all hover:from-blue-600 hover:to-purple-600"
+    >
+      Jouer tous les captchas
+    </button>
+  )
+}

--- a/captchaware/src/components/Navbar.tsx
+++ b/captchaware/src/components/Navbar.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Link from "next/link";
+import RandomCaptchaButton from "./RandomCaptchaButton.tsx";
+import ListCaptchaButton from "./ListCaptchaButton.tsx";
+
+export default function Navbar() {
+  return (
+    <nav className="sticky top-0 z-10 w-full border-white/10 border-b bg-black/20 backdrop-blur-md">
+      <div className="container mx-auto flex items-center justify-between px-4 py-3">
+        <Link href="/" className="font-bold text-white text-xl">CaptchaWare</Link>
+        <RandomCaptchaButton />
+        <ListCaptchaButton />
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
Add the ability for users to play through all captchas sequentially with a "Skip captcha" button that navigates to the next one in the sequence. This functionality:

- Adds a ListCaptchaButton to start captcha sequences
- Creates CaptchaNavigation component for skip functionality
- Refactors navbar into a dedicated component
- Uses localStorage to maintain navigation state

This makes it easier for users to experience all captchas without manually navigating between them.